### PR TITLE
Add support for columns and page margins

### DIFF
--- a/src/WriteDocx.jl
+++ b/src/WriteDocx.jl
@@ -1072,13 +1072,30 @@ Base.@kwdef struct Columns
     equal::Bool = isempty(cols)
 end
 
+"""
+    PageMargins(; top, right, bottom, left, kwargs...)
+
+Describes page margins in a [`Section`](@ref).
+
+## Keyword arguments
+
+| Keyword | Description |
+| :-- | :-- |
+| `top::`[`Twip`](@ref) | The top margin. |
+| `right::`[`Twip`](@ref) | The right margin. |
+| `bottom::`[`Twip`](@ref) | The bottom margin. |
+| `left::`[`Twip`](@ref) | The left margin. |
+| `header::`[`Twip`](@ref)`=Twip(0)` | The header margin. |
+| `footer::`[`Twip`](@ref)`=Twip(0)` | The footer margin. |
+| `gutter::`[`Twip`](@ref)`=Twip(0)` | The gutter margin. |
+"""
 Base.@kwdef struct PageMargins
     top::Twip
     right::Twip
     bottom::Twip
     left::Twip
-    header::Twip = top
-    footer::Twip = bottom
+    header::Twip = Twip(0)
+    footer::Twip = Twip(0)
     gutter::Twip = Twip(0)
 end
 

--- a/src/WriteDocx.jl
+++ b/src/WriteDocx.jl
@@ -1050,6 +1050,16 @@ Base.@kwdef struct Columns
     cols::Vector{Column} = Column[]
 end
 
+Base.@kwdef struct PageMargins
+    top::Twip
+    right::Twip
+    bottom::Twip
+    left::Twip
+    header::Twip = top
+    footer::Twip = bottom
+    gutter::Twip = Twip(0)
+end
+
 """
     SectionProperties(; kwargs...)
 
@@ -1060,6 +1070,7 @@ Holds properties for a [`Section`](@ref).
 | Keyword | Description |
 | :-- | :-- |
 | `pagesize::PageSize` | The size of each page in the section. |
+| `margins::PageMargins` | The margins for each page in the section |
 | `valign::PageVerticalAlign.T` | The vertical alignment of content on each page of the section. |
 | `headers::`[`Headers`](@ref) | Defines the header content shown at the top of each page of the section. |
 | `footers::`[`Footers`](@ref) | Defines the footer content shown at the bottom of each page of the section. |
@@ -1067,6 +1078,7 @@ Holds properties for a [`Section`](@ref).
 """
 Base.@kwdef struct SectionProperties
     pagesize::Maybe{PageSize} = nothing
+    margins::Maybe{PageMargins} = nothing
     valign::Maybe{PageVerticalAlign.T} = nothing
     headers::Maybe{Headers} = nothing
     footers::Maybe{Footers} = nothing
@@ -1605,6 +1617,9 @@ function to_xml(body::Body, rels)
         if props.pagesize !== nothing
             E.link!(section_params_node, to_xml(props.pagesize, rels))
         end
+        if props.margins !== nothing
+            E.link!(section_params_node, to_xml(props.margins, rels))
+        end
         if props.valign !== nothing
             E.link!(section_params_node, to_xml(props.valign, rels))
         end
@@ -1925,6 +1940,7 @@ function attributes(t::Union{TableCellBorder, ParagraphBorder})
     return attrs
 end
 attributes(p::PageSize) = (("w:h", p.height), ("w:w", p.width), ("w:orient", p.orientation))
+attributes(p::PageMargins) = (("w:top", p.top), ("w:right", p.right), ("w:bottom", p.bottom), ("w:left", p.left), ("w:header", p.header), ("w:footer", p.footer), ("w:gutter", p.gutter))
 attributes(p::PageVerticalAlign.T) = (("w:val", p),)
 attributes(p::Justification.T) = (("w:val", p),)
 function attributes(s::Style)
@@ -2050,6 +2066,7 @@ function xmltag(t::Tuple{ParagraphBorder, Symbol})
     throw(ArgumentError("Invalid symbol $(repr(sym)), options are :top, :left, :right, :bottom, :between."))
 end
 xmltag(::PageSize) = "w:pgSz"
+xmltag(::PageMargins) = "w:pgMar"
 xmltag(::PageVerticalAlign.T) = "w:vAlign"
 xmltag(::Columns) = "w:cols"
 xmltag(::Column) = "w:col"

--- a/src/WriteDocx.jl
+++ b/src/WriteDocx.jl
@@ -1037,17 +1037,39 @@ Base.@kwdef struct Footers
     even::Maybe{Footer} = nothing
 end
 
+"""
+    Column(; [width::Twip, space::Twip])
+
+Describes a single column. `width` sets the column width, and `space` sets the whitespace after the column (before the next column).
+
+See also: [`Columns`](@ref)
+"""
 Base.@kwdef struct Column
     width::Maybe{Twip} = nothing
     space::Maybe{Twip} = nothing
 end
 
+"""
+    Columns(; kwargs...)
+
+Sets the columns for a [`Section`](@ref).
+
+## Keyword arguments
+
+| Keyword | Description |
+| :-- | :-- |
+| `equal::Bool = true` | Whether all columns are equal-width with the same space between every column |
+| `num::Int` | The number of equal-width columns to layout. |
+| `space::`[`Twip`](@ref) | The space between equal-width columns. |
+| `sep::Bool = false` | Sets whether a vertical separator line is drawn between columns |
+| `cols::Vector{`[`Column`](@ref)`}` | A vector of custom columns. `equal`, `num`, and `space` are ignored if `cols` is provided. |
+"""
 Base.@kwdef struct Columns
-    equal::Bool = true
-    sep::Bool = false
-    space::Maybe{Twip} = nothing
     num::Int = 1
+    space::Maybe{Twip} = nothing
+    sep::Bool = false
     cols::Vector{Column} = Column[]
+    equal::Bool = isempty(cols)
 end
 
 Base.@kwdef struct PageMargins
@@ -1957,10 +1979,16 @@ end
 attributes(p::ParagraphStyle) = (("w:val", p.name),)
 attributes(p::RunStyle) = (("w:val", p.name),)
 attributes(p::VerticalAlignment.T) = (("w:val", p),)
-attributes(p::Column) = (("w:w", p.width), ("w:space", p.space))
+function attributes(p::Column)
+    attrs = Tuple{String, Any}[]
+    p.width === nothing || push!(attrs, ("w:w", p.width))
+    p.space === nothing || push!(attrs, ("w:space", p.space))
+    return attrs
+end
 function attributes(p::Columns)
     attrs = Tuple{String, Any}[]
     if p.num > 1 && p.equal
+        push!(attrs, ("w:equalWidth", p.equal))
         push!(attrs, ("w:num", p.num))
         p.sep === false || push!(attrs, ("w:sep", p.sep))
         p.space === nothing || push!(attrs, ("w:space", p.space))

--- a/test/references/columns/[Content_Types].xml
+++ b/test/references/columns/[Content_Types].xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types
+    xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+    <Default Extension="png" ContentType="image/png" />
+    <Default Extension="svg" ContentType="image/svg+xml" />
+    <Default Extension="xml" ContentType="application/xml" />
+    <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml" />
+    <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml" />
+    <Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml" />
+</Types>

--- a/test/references/columns/_rels/.rels
+++ b/test/references/columns/_rels/.rels
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships
+    xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>

--- a/test/references/columns/word/_rels/document.xml.rels
+++ b/test/references/columns/word/_rels/document.xml.rels
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
+</Relationships>

--- a/test/references/columns/word/document.xml
+++ b/test/references/columns/word/document.xml
@@ -5,11 +5,7 @@
       <w:pPr/>
       <w:r>
         <w:rPr/>
-        <w:t>Before line break</w:t>
-        <w:br w:type="textWrapping"/>
-        <w:t>after line break, before page break</w:t>
-        <w:br w:type="page"/>
-        <w:t>after page break</w:t>
+        <w:t>Section 1</w:t>
       </w:r>
     </w:p>
     <w:p>
@@ -21,13 +17,28 @@
       <w:pPr/>
       <w:r>
         <w:rPr/>
-        <w:t>column 1</w:t>
-        <w:br w:type="column"/>
-        <w:t>column 2</w:t>
+        <w:t>2 columns</w:t>
+      </w:r>
+    </w:p>
+    <w:p>
+      <w:pPr>
+        <w:sectPr>
+          <w:cols w:equalWidth="true" w:num="2"/>
+        </w:sectPr>
+      </w:pPr>
+    </w:p>
+    <w:p>
+      <w:pPr/>
+      <w:r>
+        <w:rPr/>
+        <w:t>different width columns</w:t>
       </w:r>
     </w:p>
     <w:sectPr>
-      <w:cols w:equalWidth="true" w:num="2"/>
+      <w:cols w:equalWidth="false">
+        <w:col w:w="5760" w:space="720"/>
+        <w:col w:w="2880"/>
+      </w:cols>
     </w:sectPr>
   </w:body>
 </w:document>

--- a/test/references/columns/word/styles.xml
+++ b/test/references/columns/word/styles.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:docDefaults>
+    <w:rPrDefault/>
+    <w:pPrDefault/>
+  </w:docDefaults>
+  <w:style w:type="paragraph" w:styleId="Normal">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="20"/>
+      </w:rPr>
+    </w:pPr>
+    <w:name w:val="Normal"/>
+    <w:link w:val="NormalChar"/>
+    <w:qFormat/>
+  </w:style>
+  <w:style w:type="character" w:styleId="NormalChar">
+    <w:rPr>
+      <w:sz w:val="20"/>
+    </w:rPr>
+    <w:name w:val="Normal"/>
+    <w:link w:val="Normal"/>
+    <w:qFormat/>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="Heading1">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="40"/>
+      </w:rPr>
+      <w:spacing w:before="240" w:after="200"/>
+    </w:pPr>
+    <w:name w:val="Heading 1"/>
+    <w:link w:val="Heading1Char"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="character" w:styleId="Heading1Char">
+    <w:rPr/>
+    <w:name w:val="Heading 1"/>
+    <w:link w:val="Heading1"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="Heading2">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="32"/>
+      </w:rPr>
+      <w:spacing w:before="200" w:after="160"/>
+    </w:pPr>
+    <w:name w:val="Heading 2"/>
+    <w:link w:val="Heading2Char"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="character" w:styleId="Heading2Char">
+    <w:rPr/>
+    <w:name w:val="Heading 2"/>
+    <w:link w:val="Heading2"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="Heading3">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="28"/>
+      </w:rPr>
+      <w:spacing w:before="160" w:after="120"/>
+    </w:pPr>
+    <w:name w:val="Heading 3"/>
+    <w:link w:val="Heading3Char"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="character" w:styleId="Heading3Char">
+    <w:rPr/>
+    <w:name w:val="Heading 3"/>
+    <w:link w:val="Heading3"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="Heading4">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="24"/>
+      </w:rPr>
+      <w:spacing w:before="120" w:after="80"/>
+    </w:pPr>
+    <w:name w:val="Heading 4"/>
+    <w:link w:val="Heading4Char"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="character" w:styleId="Heading4Char">
+    <w:rPr/>
+    <w:name w:val="Heading 4"/>
+    <w:link w:val="Heading4"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="Heading5">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="22"/>
+        <w:i/>
+      </w:rPr>
+      <w:spacing w:before="120" w:after="80"/>
+    </w:pPr>
+    <w:name w:val="Heading 5"/>
+    <w:link w:val="Heading5Char"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="character" w:styleId="Heading5Char">
+    <w:rPr/>
+    <w:name w:val="Heading 5"/>
+    <w:link w:val="Heading5"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="Heading6">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="20"/>
+        <w:i/>
+      </w:rPr>
+      <w:spacing w:before="120" w:after="80"/>
+    </w:pPr>
+    <w:name w:val="Heading 6"/>
+    <w:link w:val="Heading6Char"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="character" w:styleId="Heading6Char">
+    <w:rPr/>
+    <w:name w:val="Heading 6"/>
+    <w:link w:val="Heading6"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:latentStyles/>
+</w:styles>

--- a/test/references/page_margins/[Content_Types].xml
+++ b/test/references/page_margins/[Content_Types].xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types
+    xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+    <Default Extension="png" ContentType="image/png" />
+    <Default Extension="svg" ContentType="image/svg+xml" />
+    <Default Extension="xml" ContentType="application/xml" />
+    <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml" />
+    <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml" />
+    <Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml" />
+</Types>

--- a/test/references/page_margins/_rels/.rels
+++ b/test/references/page_margins/_rels/.rels
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships
+    xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>

--- a/test/references/page_margins/word/_rels/document.xml.rels
+++ b/test/references/page_margins/word/_rels/document.xml.rels
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
+</Relationships>

--- a/test/references/page_margins/word/document.xml
+++ b/test/references/page_margins/word/document.xml
@@ -5,11 +5,7 @@
       <w:pPr/>
       <w:r>
         <w:rPr/>
-        <w:t>Before line break</w:t>
-        <w:br w:type="textWrapping"/>
-        <w:t>after line break, before page break</w:t>
-        <w:br w:type="page"/>
-        <w:t>after page break</w:t>
+        <w:t>no margins</w:t>
       </w:r>
     </w:p>
     <w:p>
@@ -21,13 +17,11 @@
       <w:pPr/>
       <w:r>
         <w:rPr/>
-        <w:t>column 1</w:t>
-        <w:br w:type="column"/>
-        <w:t>column 2</w:t>
+        <w:t>thiccc margins</w:t>
       </w:r>
     </w:p>
     <w:sectPr>
-      <w:cols w:equalWidth="true" w:num="2"/>
+      <w:pgMar w:top="3600" w:right="3600" w:bottom="3600" w:left="3600" w:header="0" w:footer="0" w:gutter="0"/>
     </w:sectPr>
   </w:body>
 </w:document>

--- a/test/references/page_margins/word/styles.xml
+++ b/test/references/page_margins/word/styles.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:docDefaults>
+    <w:rPrDefault/>
+    <w:pPrDefault/>
+  </w:docDefaults>
+  <w:style w:type="paragraph" w:styleId="Normal">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="20"/>
+      </w:rPr>
+    </w:pPr>
+    <w:name w:val="Normal"/>
+    <w:link w:val="NormalChar"/>
+    <w:qFormat/>
+  </w:style>
+  <w:style w:type="character" w:styleId="NormalChar">
+    <w:rPr>
+      <w:sz w:val="20"/>
+    </w:rPr>
+    <w:name w:val="Normal"/>
+    <w:link w:val="Normal"/>
+    <w:qFormat/>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="Heading1">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="40"/>
+      </w:rPr>
+      <w:spacing w:before="240" w:after="200"/>
+    </w:pPr>
+    <w:name w:val="Heading 1"/>
+    <w:link w:val="Heading1Char"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="character" w:styleId="Heading1Char">
+    <w:rPr/>
+    <w:name w:val="Heading 1"/>
+    <w:link w:val="Heading1"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="Heading2">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="32"/>
+      </w:rPr>
+      <w:spacing w:before="200" w:after="160"/>
+    </w:pPr>
+    <w:name w:val="Heading 2"/>
+    <w:link w:val="Heading2Char"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="character" w:styleId="Heading2Char">
+    <w:rPr/>
+    <w:name w:val="Heading 2"/>
+    <w:link w:val="Heading2"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="Heading3">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="28"/>
+      </w:rPr>
+      <w:spacing w:before="160" w:after="120"/>
+    </w:pPr>
+    <w:name w:val="Heading 3"/>
+    <w:link w:val="Heading3Char"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="character" w:styleId="Heading3Char">
+    <w:rPr/>
+    <w:name w:val="Heading 3"/>
+    <w:link w:val="Heading3"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="Heading4">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="24"/>
+      </w:rPr>
+      <w:spacing w:before="120" w:after="80"/>
+    </w:pPr>
+    <w:name w:val="Heading 4"/>
+    <w:link w:val="Heading4Char"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="character" w:styleId="Heading4Char">
+    <w:rPr/>
+    <w:name w:val="Heading 4"/>
+    <w:link w:val="Heading4"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="Heading5">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="22"/>
+        <w:i/>
+      </w:rPr>
+      <w:spacing w:before="120" w:after="80"/>
+    </w:pPr>
+    <w:name w:val="Heading 5"/>
+    <w:link w:val="Heading5Char"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="character" w:styleId="Heading5Char">
+    <w:rPr/>
+    <w:name w:val="Heading 5"/>
+    <w:link w:val="Heading5"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="Heading6">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="20"/>
+        <w:i/>
+      </w:rPr>
+      <w:spacing w:before="120" w:after="80"/>
+    </w:pPr>
+    <w:name w:val="Heading 6"/>
+    <w:link w:val="Heading6Char"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="character" w:styleId="Heading6Char">
+    <w:rPr/>
+    <w:name w:val="Heading 6"/>
+    <w:link w:val="Heading6"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:latentStyles/>
+</w:styles>

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -708,6 +708,59 @@ Base.show(io::IO, ::MIME"image/png", p::PNG) = write(io, p.bytes)
         reftest_docx(doc, "multiple_sections")
     end
 
+    @testset "Columns" begin
+        doc = W.Document(
+            W.Body([
+                W.Section([
+                    W.Paragraph([
+                        W.Run([
+                            W.Text("Section 1")
+                        ])
+                    ])
+                ])
+                W.Section([
+                    W.Paragraph([
+                        W.Run([
+                            W.Text("2 columns")
+                        ])
+                    ])
+                ]; columns=W.Columns(;num=2))
+                W.Section([
+                    W.Paragraph([
+                        W.Run([
+                            W.Text("different width columns")
+                        ])
+                    ])
+                    ]; columns=W.Columns(;cols=[W.Column(;width=4W.inch, space=0.5W.inch), W.Column(;width=2W.inch)]))
+            ])
+        )
+
+        reftest_docx(doc, "columns")
+    end
+
+    @testset "Page margins" begin
+        doc = W.Document(
+            W.Body([
+                W.Section([
+                    W.Paragraph([
+                        W.Run([
+                            W.Text("no margins")
+                        ])
+                    ])
+                ])
+                W.Section([
+                    W.Paragraph([
+                        W.Run([
+                            W.Text("thiccc margins")
+                        ])
+                    ])
+                ]; margins=W.PageMargins(;top=2.5W.inch, right=2.5W.inch, bottom=2.5W.inch, left=2.5W.inch))
+            ])
+        )
+
+        reftest_docx(doc, "page_margins")
+    end
+
     @testset "Page sizes" begin
         doc = W.Document(
             W.Body(
@@ -892,6 +945,17 @@ Base.show(io::IO, ::MIME"image/png", p::PNG) = write(io, p.bytes)
                             )
                         ])
                     ])
+                    W.Section([
+                        W.Paragraph([
+                            W.Run(
+                                [
+                                    W.Text("column 1"),
+                                    W.Break(W.BreakType.column),
+                                    W.Text("column 2"),
+                                ]
+                            )
+                        ])
+                    ]; columns=W.Columns(;num=2))
                 ]
             )
         )


### PR DESCRIPTION
I followed the ECMA-376 spec for both columns (definitions/descriptions in §17.6.3 and
17.6.4), and margins (§17.6.11).

Fixes #30.
