### PR TITLE
Add table width/layout, tab stops, and bookmarks

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -30,4 +30,9 @@ WriteDocx.UnderlinePattern
 WriteDocx.ShadingPattern
 WriteDocx.VerticalAlign
 WriteDocx.VerticalAlignment
+WriteDocx.TableLayout
+WriteDocx.TableWidthType
+WriteDocx.TabAlignment
+WriteDocx.TabLeader
+WriteDocx.LineRule
 ```

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -31,8 +31,6 @@ WriteDocx.ShadingPattern
 WriteDocx.VerticalAlign
 WriteDocx.VerticalAlignment
 WriteDocx.TableLayout
-WriteDocx.TableWidthType
 WriteDocx.TabAlignment
 WriteDocx.TabLeader
-WriteDocx.LineRule
 ```

--- a/src/WriteDocx.jl
+++ b/src/WriteDocx.jl
@@ -228,6 +228,16 @@ is_inline_element(::Type{Break}) = true
 
 Break() = Break(BreakType.text_wrapping)
 
+"""
+    Tab()
+
+A tab character in a [`Run`](@ref). It advances to the next [`TabStop`](@ref)
+defined on the paragraph.
+"""
+struct Tab end
+
+is_inline_element(::Type{Tab}) = true
+
 struct Size
     size::HalfPoint
 end
@@ -643,9 +653,29 @@ An enum that can be either `start`, `stop`, `center`, `both` or `distribute`.
 """
 @enumx Justification start stop center both distribute
 
+"""
+    LineRule
+
+An enum that can be either `auto`, `exact` or `at_least`, setting how a
+paragraph's [`Spacing`](@ref) `line` value is interpreted: `auto` is a multiple
+of single spacing (`line = 240` is single, `360` is 1.5), `exact` is an exact
+height in twips, `at_least` a minimum height in twips.
+"""
+@enumx LineRule auto exact at_least
+
+"""
+    Spacing
+
+Paragraph spacing. `before` and `after` set the space above and below the
+paragraph. `line` sets the line height, interpreted according to `line_rule`
+(a `LineRule`): with `auto`, `line = 240` is single spacing and `360` is 1.5;
+with `exact` or `at_least`, `line` is a height in twips.
+"""
 Base.@kwdef struct Spacing
     before::Maybe{Twip} = nothing
     after::Maybe{Twip} = nothing
+    line::Maybe{Int} = nothing
+    line_rule::Maybe{LineRule.T} = nothing
 end
 
 """
@@ -659,6 +689,41 @@ Base.@kwdef struct Shading
     pattern::ShadingPattern.T = ShadingPattern.clear
     fill::AutomaticDefault{HexColor} = automatic
     color::AutomaticDefault{HexColor} = automatic
+end
+
+"""
+    TabAlignment
+
+An enum that can be either `left`, `center`, `right`, `decimal`, `bar` or `clear`.
+"""
+@enumx TabAlignment left center right decimal bar clear
+
+"""
+    TabLeader
+
+An enum that can be either `none`, `dot`, `hyphen`, `underscore`, `heavy` or
+`middle_dot`, the fill character drawn across the space a tab jumps.
+"""
+@enumx TabLeader none dot hyphen underscore heavy middle_dot
+
+"""
+    TabStop(position::Twip; alignment=TabAlignment.left, leader=TabLeader.none)
+
+A tab stop in a [`ParagraphProperties`](@ref). `position` is measured from the
+left margin; `leader` fills the jumped space (a right-aligned stop with a `dot`
+leader is the classic table-of-contents dotted line).
+"""
+struct TabStop
+    position::Twip
+    alignment::TabAlignment.T
+    leader::TabLeader.T
+end
+TabStop(position::Twip; alignment::TabAlignment.T = TabAlignment.left, leader::TabLeader.T = TabLeader.none) =
+    TabStop(position, alignment, leader)
+
+# Wraps a paragraph's tab stops in the required <w:tabs> container.
+struct TabStops
+    tabs::Vector{TabStop}
 end
 
 """
@@ -684,6 +749,7 @@ Base.@kwdef struct ParagraphProperties
     spacing::Maybe{Spacing} = nothing
     borders::Maybe{ParagraphBorders} = nothing
     shading::Maybe{Shading} = nothing
+    tabs::Maybe{Vector{TabStop}} = nothing
 end
 
 """
@@ -755,6 +821,43 @@ Run(children::AbstractVector; kwargs...) = Run(children, RunProperties(; kwargs.
 is_run_element(::Type{Run}) = true
 
 """
+    TableWidthType
+
+The unit tag stored in a [`TableWidth`](@ref): `pct` (fiftieths of a percent), `dxa` (twips),
+or `auto` (sized to content). Construct widths through [`TableWidth`](@ref) rather than this enum.
+"""
+@enumx TableWidthType pct dxa auto
+
+"""
+    TableWidth(; pct = nothing, dxa = nothing)
+
+Width of a table (`TableProperties.width`) or table cell (`TableCellProperties.width`).
+
+Pass `pct` for a percentage of the surrounding text column; `pct = 100` fills the page
+(Word's "AutoFit to window"). Pass `dxa` for an absolute width in twips. With neither, the
+width is `auto` (sized to content), which is also the behaviour when `width` is left `nothing`.
+"""
+struct TableWidth
+    type::TableWidthType.T
+    value::Int     # pct: fiftieths of a percent (100% -> 5000); dxa: twips; auto: unused
+end
+function TableWidth(; pct = nothing, dxa = nothing)
+    pct === nothing || dxa === nothing ||
+        throw(ArgumentError("TableWidth takes `pct` or `dxa`, not both."))
+    pct !== nothing && return TableWidth(TableWidthType.pct, round(Int, pct * 50))
+    dxa !== nothing && return TableWidth(TableWidthType.dxa, round(Int, dxa))
+    return TableWidth(TableWidthType.auto, 0)
+end
+
+"""
+    TableLayout
+
+An enum that can be either `autofit` or `fixed`. `fixed` honors the column widths
+given by the table grid; `autofit` (Word's default) sizes columns to content.
+"""
+@enumx TableLayout autofit fixed
+
+"""
     TableProperties(; kwargs...)
 
 Holds properties for a [`Table`](@ref).
@@ -764,11 +867,15 @@ All properties are optional.
 
 | Keyword | Description |
 | :-- | :-- |
+| `width::TableWidth` | The table width, e.g. `TableWidth(pct = 100)` to fill the page. |
 | `margins::TableLevelCellMargins` | Margins for all cells in the table. |
 | `spacing::Twip` | The space between adjacent cells and the edges of the table. |
 | `justification::`[`Justification`](@ref)`.T` | The justification of the table. |
+| `layout::`[`TableLayout`](@ref)`.T` | The layout algorithm: `fixed` honors the specified column widths, `autofit` (Word's default) sizes columns to content. |
 """
 Base.@kwdef struct TableProperties
+    width::Maybe{TableWidth} = nothing
+    layout::Maybe{TableLayout.T} = nothing
     margins::Maybe{TableLevelCellMargins} = nothing
     spacing::Maybe{Twip} = nothing
     justification::Maybe{Justification.T} = nothing
@@ -818,6 +925,7 @@ All properties are optional.
 
 | Keyword | Description |
 | :-- | :-- |
+| `width::TableWidth` | The width of the cell. |
 | `borders::TableCellBorders` | The border style of the cell. |
 | `vertical_merge::Bool` | Should be set to `true` if this cell should be merged with the one above it. |
 | `gridspan::Int` | The number of cells this cell should span in horizontal direction. |
@@ -826,6 +934,7 @@ All properties are optional.
 | `hide_mark::Bool` | If `true`, hides the editor mark so that the table cell can fully collapse if it's empty. |
 """
 Base.@kwdef struct TableCellProperties
+    width::Maybe{TableWidth} = nothing
     borders::Maybe{TableCellBorders} = nothing
     vertical_merge::Maybe{Bool} = nothing
     gridspan::Maybe{Int} = nothing
@@ -875,6 +984,32 @@ Every [`ComplexField`](@ref) element must be paired with this element.
 struct ComplexFieldEnd end
 
 is_run_element(::Type{ComplexFieldEnd}) = true
+
+"""
+    BookmarkStart(id::Int, name::String)
+
+Marks the start of a bookmark. `name` is the target that internal hyperlinks and
+cross-references point at (via a `HYPERLINK \\l` field or `w:anchor`); `id` is a numeric
+handle that must be unique across the whole document and must match the paired
+[`BookmarkEnd`](@ref). Content to be bookmarked may appear between the two.
+"""
+struct BookmarkStart
+    id::Int
+    name::String
+end
+
+is_run_element(::Type{BookmarkStart}) = true
+
+"""
+    BookmarkEnd(id::Int)
+
+Marks the end of the bookmark opened by the [`BookmarkStart`](@ref) with the same `id`.
+"""
+struct BookmarkEnd
+    id::Int
+end
+
+is_run_element(::Type{BookmarkEnd}) = true
 
 is_block_element(x) = false
 
@@ -933,20 +1068,25 @@ end
 TableRow(cells; kwargs...) = TableRow(cells, TableRowProperties(; kwargs...))
 
 """
-    Table(rows::Vector{TableRow}, properties::TableProperties)
-    Table(rows; kwargs...)
+    Table(rows::Vector{TableRow}, properties::TableProperties, grid = Twip[])
+    Table(rows; grid = Twip[], kwargs...)
 
-A table which can hold a vector of [`TableRow`](@ref)s.
-The second convenience constructor forwards all keyword arguments to [`TableProperties`](@ref).
+A table which can hold a vector of [`TableRow`](@ref)s. `grid` gives explicit
+column widths (a `<w:tblGrid>`); a fixed-layout table (`TableProperties.layout =
+TableLayout.fixed`) needs one whose widths sum to the table width. The second
+convenience constructor forwards remaining keyword arguments to [`TableProperties`](@ref).
 """
 struct Table
     rows::Vector{TableRow}
     properties::TableProperties
+    grid::Vector{Twip}
+
+    Table(rows, properties, grid = Twip[]) = new(rows, properties, grid)
 end
 
 is_block_element(::Type{Table}) = true
 
-Table(rows; kwargs...) = Table(rows, TableProperties(; kwargs...))
+Table(rows; grid::Vector{Twip} = Twip[], kwargs...) = Table(rows, TableProperties(; kwargs...), grid)
 
 @enumx PageOrientation landscape portrait
 
@@ -1884,7 +2024,9 @@ children(section::Section) = section.children
 children(paragraph::Paragraph) = paragraph.children
 children(run::Run) = run.children
 children(text::Text) = (text.text,)
-children(table::Table) = table.rows
+children(table::Table) =
+    isempty(table.grid) ? table.rows :
+    [xml("w:tblGrid", [xml("w:gridCol", "w:w" => w) for w in table.grid]); table.rows]
 children(tablerow::TableRow) = tablerow.cells
 children(tablecell::TableCell) = tablecell.children
 children(h::Header) = h.children
@@ -1908,6 +2050,7 @@ function children(p::ParagraphProperties)
     p.style === nothing || push!(c, ParagraphStyle(p.style))
     p.run_properties === nothing || push!(c, p.run_properties)
     p.justification === nothing || push!(c, p.justification)
+    p.tabs === nothing || push!(c, TabStops(p.tabs))
     p.spacing === nothing || push!(c, p.spacing)
     p.borders === nothing || push!(c, p.borders)
     p.shading === nothing || push!(c, p.shading)
@@ -1916,6 +2059,8 @@ function children(p::ParagraphProperties)
     something(p.keep_lines, false) && push!(c, xml("w:keepLines"))
     return c
 end
+
+children(t::TabStops) = t.tabs
 
 function children(p::Columns)
     c = []
@@ -1927,6 +2072,7 @@ end
 
 function children(p::TableCellProperties)
     c = []
+    p.width === nothing || push!(c, xml("w:tcW", "w:type" => p.width.type, "w:w" => p.width.value))
     p.borders === nothing || push!(c, p.borders)
     p.vertical_merge === nothing || push!(c, VerticalMerge(p.vertical_merge))
     p.gridspan === nothing || push!(c, GridSpan(p.gridspan))
@@ -1937,10 +2083,13 @@ function children(p::TableCellProperties)
 end
 
 function children(p::TableProperties)
+    # Child order follows the CT_TblPrBase schema sequence: tblW, tblJc, tblCellSpacing, tblLayout, tblCellMar.
     c = []
-    p.margins === nothing || push!(c, p.margins)
-    p.spacing === nothing || push!(c, xml("w:tblCellSpacing", "w:w" => p.spacing))
+    p.width === nothing || push!(c, xml("w:tblW", "w:type" => p.width.type, "w:w" => p.width.value))
     p.justification === nothing || push!(c, p.justification)
+    p.spacing === nothing || push!(c, xml("w:tblCellSpacing", "w:type" => "dxa", "w:w" => p.spacing))
+    p.layout === nothing || push!(c, xml("w:tblLayout", "w:type" => p.layout))
+    p.margins === nothing || push!(c, p.margins)
     return c
 end
 
@@ -2051,6 +2200,7 @@ function attributes(t::Text)
     return attrs
 end
 attributes(b::Break) = (("w:type", b.type),)
+attributes(t::TabStop) = (("w:val", t.alignment), ("w:leader", t.leader), ("w:pos", t.position))
 function attributes(x::Union{Header, Footer})
     [
         ("xmlns:w", "http://schemas.openxmlformats.org/wordprocessingml/2006/main"),
@@ -2063,10 +2213,14 @@ function attributes(s::SimpleField)
     s.dirty === nothing || push!(attrs, ("w:dirty", s.dirty))
     return attrs
 end
+attributes(b::BookmarkStart) = (("w:id", b.id), ("w:name", b.name))
+attributes(b::BookmarkEnd) = (("w:id", b.id),)
 function attributes(s::Spacing)
     attrs = Tuple{String, Any}[]
     s.before === nothing || push!(attrs, ("w:before", s.before))
     s.after === nothing || push!(attrs, ("w:after", s.after))
+    s.line === nothing || push!(attrs, ("w:line", s.line))
+    s.line_rule === nothing || push!(attrs, ("w:lineRule", s.line_rule))
     return attrs
 end
 function attributes(s::Shading)
@@ -2141,9 +2295,14 @@ xmltag(::TableCellMargins) = "w:tcMar"
 xmltag(::TableLevelCellMargins) = "w:tblCellMar"
 xmltag(::VerticalAlign.T) = "w:vAlign"
 xmltag(::Break) = "w:br"
+xmltag(::Tab) = "w:tab"
+xmltag(::TabStop) = "w:tab"
+xmltag(::TabStops) = "w:tabs"
 xmltag(::Header) = "w:hdr"
 xmltag(::Footer) = "w:ftr"
 xmltag(::SimpleField) = "w:fldSimple"
+xmltag(::BookmarkStart) = "w:bookmarkStart"
+xmltag(::BookmarkEnd) = "w:bookmarkEnd"
 xmltag(::Spacing) = "w:spacing"
 xmltag(::TableRowProperties) = "w:trPr"
 xmltag(::TableRowHeight) = "w:trHeight"
@@ -2162,8 +2321,13 @@ xmlstring(p::PageOrientation.T) = string(p)
 xmlstring(p::PageVerticalAlign.T) = string(p)
 xmlstring(p::Justification.T) = p === Justification.stop ? "end" : string(p)
 xmlstring(l::Length) = string(round(Int, l.value)) # all sizes should be converted at this point and word only wants integers
+xmlstring(l::TableLayout.T) = string(l)
+xmlstring(t::TableWidthType.T) = string(t)
 xmlstring(v::VerticalAlign.T) = string(v)
 xmlstring(b::BreakType.T) = snake_to_camel(string(b))
+xmlstring(a::TabAlignment.T) = string(a)
+xmlstring(l::TabLeader.T) = snake_to_camel(string(l))
+xmlstring(l::LineRule.T) = snake_to_camel(string(l))
 xmlstring(b::HeightRule.T) = snake_to_camel(string(b))
 xmlstring(b::ShadingPattern.T) = snake_to_camel(string(b))
 end

--- a/src/WriteDocx.jl
+++ b/src/WriteDocx.jl
@@ -123,6 +123,22 @@ Base.:(/)(l::L, r::Real) where L <: Length = L(l.value / r)
 Base.:(+)(l::L, l2::Length) where L <: Length = L(l.value + convert(L, l2).value)
 Base.:(-)(l::L, l2::Length) where L <: Length = L(l.value - convert(L, l2).value)
 
+"""
+    Percent(value::Float64)
+
+A relative measure, for the places where Word accepts a proportion of some other
+quantity instead of an absolute [`Length`](@ref), such as the `width` of a
+[`TableProperties`](@ref) or the `line` of a [`Spacing`](@ref).
+For convenience, the constant `percent` is provided for `Percent(1)`.
+"""
+struct Percent
+    value::Float64
+end
+const percent = Percent(1)
+
+Base.:(*)(x::Real, p::Percent) = Percent(p.value * x)
+Base.:(*)(p::Percent, x::Real) = x * p
+
 const Maybe = Union{Nothing, <:Any}
 
 macro partialkw(expr::Expr)
@@ -654,28 +670,29 @@ An enum that can be either `start`, `stop`, `center`, `both` or `distribute`.
 @enumx Justification start stop center both distribute
 
 """
-    LineRule
+    AtLeast(length)
 
-An enum that can be either `auto`, `exact` or `at_least`, setting how a
-paragraph's [`Spacing`](@ref) `line` value is interpreted: `auto` is a multiple
-of single spacing (`line = 240` is single, `360` is 1.5), `exact` is an exact
-height in twips, `at_least` a minimum height in twips.
+A minimum [`Length`](@ref), for the places where Word may grow a measure beyond
+the value given to fit its content, such as the `line` of a [`Spacing`](@ref).
 """
-@enumx LineRule auto exact at_least
+struct AtLeast
+    length::Twip
+end
 
 """
-    Spacing
+    Spacing(; before = nothing, after = nothing, line = nothing)
 
 Paragraph spacing. `before` and `after` set the space above and below the
-paragraph. `line` sets the line height, interpreted according to `line_rule`
-(a `LineRule`): with `auto`, `line = 240` is single spacing and `360` is 1.5;
-with `exact` or `at_least`, `line` is a height in twips.
+paragraph. `line` sets the line height and takes one of three kinds of value:
+
+  - a [`Percent`](@ref) of single spacing, so `line = 150percent` is one-and-a-half spacing
+  - a [`Length`](@ref), for lines fixed at exactly that height, such as `line = 14pt`
+  - an [`AtLeast`](@ref), for a height that may grow to fit tall content
 """
 Base.@kwdef struct Spacing
     before::Maybe{Twip} = nothing
     after::Maybe{Twip} = nothing
-    line::Maybe{Int} = nothing
-    line_rule::Maybe{LineRule.T} = nothing
+    line::Maybe{Union{Length, Percent, AtLeast}} = nothing
 end
 
 """
@@ -707,7 +724,7 @@ An enum that can be either `none`, `dot`, `hyphen`, `underscore`, `heavy` or
 @enumx TabLeader none dot hyphen underscore heavy middle_dot
 
 """
-    TabStop(position::Twip; alignment=TabAlignment.left, leader=TabLeader.none)
+    TabStop(position::Length; alignment = TabAlignment.left, leader = TabLeader.none)
 
 A tab stop in a [`ParagraphProperties`](@ref). `position` is measured from the
 left margin; `leader` fills the jumped space (a right-aligned stop with a `dot`
@@ -718,7 +735,7 @@ struct TabStop
     alignment::TabAlignment.T
     leader::TabLeader.T
 end
-TabStop(position::Twip; alignment::TabAlignment.T = TabAlignment.left, leader::TabLeader.T = TabLeader.none) =
+TabStop(position::Length; alignment::TabAlignment.T = TabAlignment.left, leader::TabLeader.T = TabLeader.none) =
     TabStop(position, alignment, leader)
 
 # Wraps a paragraph's tab stops in the required <w:tabs> container.
@@ -821,33 +838,24 @@ Run(children::AbstractVector; kwargs...) = Run(children, RunProperties(; kwargs.
 is_run_element(::Type{Run}) = true
 
 """
-    TableWidthType
+    TableWidth(value)
 
-The unit tag stored in a [`TableWidth`](@ref): `pct` (fiftieths of a percent), `dxa` (twips),
-or `auto` (sized to content). Construct widths through [`TableWidth`](@ref) rather than this enum.
-"""
-@enumx TableWidthType pct dxa auto
+The width of a table (`TableProperties.width`) or table cell (`TableCellProperties.width`),
+which is one of:
 
-"""
-    TableWidth(; pct = nothing, dxa = nothing)
+  - a [`Percent`](@ref) of the surrounding text column, so `100percent` fills it
+    (Word's "AutoFit to window")
+  - a [`Length`](@ref), for an absolute width such as `12cm`
+  - `automatic`, sizing the table or cell to its content
 
-Width of a table (`TableProperties.width`) or table cell (`TableCellProperties.width`).
-
-Pass `pct` for a percentage of the surrounding text column; `pct = 100` fills the page
-(Word's "AutoFit to window"). Pass `dxa` for an absolute width in twips. With neither, the
-width is `auto` (sized to content), which is also the behaviour when `width` is left `nothing`.
+The bare value can be passed as the `width` as well, so `width = 100percent` and
+`width = TableWidth(100percent)` are equivalent.
 """
 struct TableWidth
-    type::TableWidthType.T
-    value::Int     # pct: fiftieths of a percent (100% -> 5000); dxa: twips; auto: unused
+    value::Union{Length, Percent, Automatic}
 end
-function TableWidth(; pct = nothing, dxa = nothing)
-    pct === nothing || dxa === nothing ||
-        throw(ArgumentError("TableWidth takes `pct` or `dxa`, not both."))
-    pct !== nothing && return TableWidth(TableWidthType.pct, round(Int, pct * 50))
-    dxa !== nothing && return TableWidth(TableWidthType.dxa, round(Int, dxa))
-    return TableWidth(TableWidthType.auto, 0)
-end
+
+Base.convert(::Type{TableWidth}, value::Union{Length, Percent, Automatic}) = TableWidth(value)
 
 """
     TableLayout
@@ -867,7 +875,7 @@ All properties are optional.
 
 | Keyword | Description |
 | :-- | :-- |
-| `width::TableWidth` | The table width, e.g. `TableWidth(pct = 100)` to fill the page. |
+| `width::`[`TableWidth`](@ref) | The table width, e.g. `100percent` to fill the page or `12cm`. |
 | `margins::TableLevelCellMargins` | Margins for all cells in the table. |
 | `spacing::Twip` | The space between adjacent cells and the edges of the table. |
 | `justification::`[`Justification`](@ref)`.T` | The justification of the table. |
@@ -925,7 +933,7 @@ All properties are optional.
 
 | Keyword | Description |
 | :-- | :-- |
-| `width::TableWidth` | The width of the cell. |
+| `width::`[`TableWidth`](@ref) | The width of the cell, e.g. `50percent` or `4cm`. |
 | `borders::TableCellBorders` | The border style of the cell. |
 | `vertical_merge::Bool` | Should be set to `true` if this cell should be merged with the one above it. |
 | `gridspan::Int` | The number of cells this cell should span in horizontal direction. |
@@ -1071,10 +1079,11 @@ TableRow(cells; kwargs...) = TableRow(cells, TableRowProperties(; kwargs...))
     Table(rows::Vector{TableRow}, properties::TableProperties, grid = Twip[])
     Table(rows; grid = Twip[], kwargs...)
 
-A table which can hold a vector of [`TableRow`](@ref)s. `grid` gives explicit
-column widths (a `<w:tblGrid>`); a fixed-layout table (`TableProperties.layout =
-TableLayout.fixed`) needs one whose widths sum to the table width. The second
-convenience constructor forwards remaining keyword arguments to [`TableProperties`](@ref).
+A table which can hold a vector of [`TableRow`](@ref)s. `grid` gives explicit column
+widths as [`Length`](@ref)s (a `<w:tblGrid>`), so `grid = [4cm, 2cm]` is accepted; a
+fixed-layout table (`TableProperties.layout = TableLayout.fixed`) needs one whose widths
+sum to the table width. The second convenience constructor forwards remaining keyword
+arguments to [`TableProperties`](@ref).
 """
 struct Table
     rows::Vector{TableRow}
@@ -1086,7 +1095,8 @@ end
 
 is_block_element(::Type{Table}) = true
 
-Table(rows; grid::Vector{Twip} = Twip[], kwargs...) = Table(rows, TableProperties(; kwargs...), grid)
+Table(rows; grid::AbstractVector{<:Length} = Twip[], kwargs...) =
+    Table(rows, TableProperties(; kwargs...), grid)
 
 @enumx PageOrientation landscape portrait
 
@@ -2070,9 +2080,16 @@ function children(p::Columns)
     return c
 end
 
+# `w:tblW` and `w:tcW` pair a number with the unit tag that gives it meaning, and Word measures
+# percentages in fiftieths of a percent.
+width_attributes(w::TableWidth) = width_attributes(w.value)
+width_attributes(l::Length) = ("w:type" => "dxa", "w:w" => Twip(l))
+width_attributes(p::Percent) = ("w:type" => "pct", "w:w" => round(Int, 50 * p.value))
+width_attributes(::Automatic) = ("w:type" => "auto", "w:w" => 0)
+
 function children(p::TableCellProperties)
     c = []
-    p.width === nothing || push!(c, xml("w:tcW", "w:type" => p.width.type, "w:w" => p.width.value))
+    p.width === nothing || push!(c, xml("w:tcW", width_attributes(p.width)...))
     p.borders === nothing || push!(c, p.borders)
     p.vertical_merge === nothing || push!(c, VerticalMerge(p.vertical_merge))
     p.gridspan === nothing || push!(c, GridSpan(p.gridspan))
@@ -2085,7 +2102,7 @@ end
 function children(p::TableProperties)
     # Child order follows the CT_TblPrBase schema sequence: tblW, tblJc, tblCellSpacing, tblLayout, tblCellMar.
     c = []
-    p.width === nothing || push!(c, xml("w:tblW", "w:type" => p.width.type, "w:w" => p.width.value))
+    p.width === nothing || push!(c, xml("w:tblW", width_attributes(p.width)...))
     p.justification === nothing || push!(c, p.justification)
     p.spacing === nothing || push!(c, xml("w:tblCellSpacing", "w:type" => "dxa", "w:w" => p.spacing))
     p.layout === nothing || push!(c, xml("w:tblLayout", "w:type" => p.layout))
@@ -2215,12 +2232,17 @@ function attributes(s::SimpleField)
 end
 attributes(b::BookmarkStart) = (("w:id", b.id), ("w:name", b.name))
 attributes(b::BookmarkEnd) = (("w:id", b.id),)
+# `w:line` is a bare number whose meaning comes from `w:lineRule`, so the rule follows from the
+# kind of value the user passed. Word counts a proportion in 240ths of a line and the rest in twips.
+line_attributes(p::Percent) = (("w:line", round(Int, 2.4 * p.value)), ("w:lineRule", "auto"))
+line_attributes(l::Length) = (("w:line", Twip(l)), ("w:lineRule", "exact"))
+line_attributes(a::AtLeast) = (("w:line", a.length), ("w:lineRule", "atLeast"))
+
 function attributes(s::Spacing)
     attrs = Tuple{String, Any}[]
     s.before === nothing || push!(attrs, ("w:before", s.before))
     s.after === nothing || push!(attrs, ("w:after", s.after))
-    s.line === nothing || push!(attrs, ("w:line", s.line))
-    s.line_rule === nothing || push!(attrs, ("w:lineRule", s.line_rule))
+    s.line === nothing || append!(attrs, line_attributes(s.line))
     return attrs
 end
 function attributes(s::Shading)
@@ -2322,12 +2344,10 @@ xmlstring(p::PageVerticalAlign.T) = string(p)
 xmlstring(p::Justification.T) = p === Justification.stop ? "end" : string(p)
 xmlstring(l::Length) = string(round(Int, l.value)) # all sizes should be converted at this point and word only wants integers
 xmlstring(l::TableLayout.T) = string(l)
-xmlstring(t::TableWidthType.T) = string(t)
 xmlstring(v::VerticalAlign.T) = string(v)
 xmlstring(b::BreakType.T) = snake_to_camel(string(b))
 xmlstring(a::TabAlignment.T) = string(a)
 xmlstring(l::TabLeader.T) = snake_to_camel(string(l))
-xmlstring(l::LineRule.T) = snake_to_camel(string(l))
 xmlstring(b::HeightRule.T) = snake_to_camel(string(b))
 xmlstring(b::ShadingPattern.T) = snake_to_camel(string(b))
 end

--- a/test/references/table_width_tabs_bookmarks/[Content_Types].xml
+++ b/test/references/table_width_tabs_bookmarks/[Content_Types].xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types
+    xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+    <Default Extension="png" ContentType="image/png" />
+    <Default Extension="svg" ContentType="image/svg+xml" />
+    <Default Extension="xml" ContentType="application/xml" />
+    <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml" />
+    <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml" />
+    <Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml" />
+</Types>

--- a/test/references/table_width_tabs_bookmarks/_rels/.rels
+++ b/test/references/table_width_tabs_bookmarks/_rels/.rels
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships
+    xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>

--- a/test/references/table_width_tabs_bookmarks/word/_rels/document.xml.rels
+++ b/test/references/table_width_tabs_bookmarks/word/_rels/document.xml.rels
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
+</Relationships>

--- a/test/references/table_width_tabs_bookmarks/word/document.xml
+++ b/test/references/table_width_tabs_bookmarks/word/document.xml
@@ -4,7 +4,15 @@
     <w:tbl>
       <w:tblPr>
         <w:tblW w:type="pct" w:w="5000"/>
+        <w:jc w:val="center"/>
+        <w:tblCellSpacing w:type="dxa" w:w="50"/>
         <w:tblLayout w:type="fixed"/>
+        <w:tblCellMar>
+          <w:top w:w="100"/>
+          <w:bottom w:w="100"/>
+          <w:start w:w="100"/>
+          <w:end w:w="100"/>
+        </w:tblCellMar>
       </w:tblPr>
       <w:tblGrid>
         <w:gridCol w:w="3000"/>

--- a/test/references/table_width_tabs_bookmarks/word/document.xml
+++ b/test/references/table_width_tabs_bookmarks/word/document.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
+  <w:body>
+    <w:tbl>
+      <w:tblPr>
+        <w:tblW w:type="pct" w:w="5000"/>
+        <w:tblLayout w:type="fixed"/>
+      </w:tblPr>
+      <w:tblGrid>
+        <w:gridCol w:w="3000"/>
+        <w:gridCol w:w="3000"/>
+      </w:tblGrid>
+      <w:tr>
+        <w:trPr/>
+        <w:tc>
+          <w:tcPr>
+            <w:tcW w:type="dxa" w:w="3000"/>
+          </w:tcPr>
+          <w:p>
+            <w:pPr/>
+            <w:r>
+              <w:rPr/>
+              <w:t>A</w:t>
+            </w:r>
+          </w:p>
+        </w:tc>
+        <w:tc>
+          <w:tcPr/>
+          <w:p>
+            <w:pPr/>
+            <w:r>
+              <w:rPr/>
+              <w:t>B</w:t>
+            </w:r>
+          </w:p>
+        </w:tc>
+      </w:tr>
+    </w:tbl>
+    <w:p>
+      <w:pPr>
+        <w:tabs>
+          <w:tab w:val="center" w:leader="dot" w:pos="4320"/>
+        </w:tabs>
+        <w:spacing w:line="360" w:lineRule="atLeast"/>
+      </w:pPr>
+      <w:r>
+        <w:rPr/>
+        <w:t>left</w:t>
+        <w:tab/>
+        <w:t>centered</w:t>
+      </w:r>
+    </w:p>
+    <w:p>
+      <w:pPr/>
+      <w:bookmarkStart w:id="1" w:name="target"/>
+      <w:r>
+        <w:rPr/>
+        <w:t>bookmarked</w:t>
+      </w:r>
+      <w:bookmarkEnd w:id="1"/>
+    </w:p>
+    <w:sectPr/>
+  </w:body>
+</w:document>

--- a/test/references/table_width_tabs_bookmarks/word/styles.xml
+++ b/test/references/table_width_tabs_bookmarks/word/styles.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:docDefaults>
+    <w:rPrDefault/>
+    <w:pPrDefault/>
+  </w:docDefaults>
+  <w:style w:type="paragraph" w:styleId="Normal">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="20"/>
+      </w:rPr>
+    </w:pPr>
+    <w:name w:val="Normal"/>
+    <w:link w:val="NormalChar"/>
+    <w:qFormat/>
+  </w:style>
+  <w:style w:type="character" w:styleId="NormalChar">
+    <w:rPr>
+      <w:sz w:val="20"/>
+    </w:rPr>
+    <w:name w:val="Normal"/>
+    <w:link w:val="Normal"/>
+    <w:qFormat/>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="Heading1">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="40"/>
+      </w:rPr>
+      <w:spacing w:before="240" w:after="200"/>
+    </w:pPr>
+    <w:name w:val="Heading 1"/>
+    <w:link w:val="Heading1Char"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="character" w:styleId="Heading1Char">
+    <w:rPr/>
+    <w:name w:val="Heading 1"/>
+    <w:link w:val="Heading1"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="Heading2">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="32"/>
+      </w:rPr>
+      <w:spacing w:before="200" w:after="160"/>
+    </w:pPr>
+    <w:name w:val="Heading 2"/>
+    <w:link w:val="Heading2Char"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="character" w:styleId="Heading2Char">
+    <w:rPr/>
+    <w:name w:val="Heading 2"/>
+    <w:link w:val="Heading2"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="Heading3">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="28"/>
+      </w:rPr>
+      <w:spacing w:before="160" w:after="120"/>
+    </w:pPr>
+    <w:name w:val="Heading 3"/>
+    <w:link w:val="Heading3Char"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="character" w:styleId="Heading3Char">
+    <w:rPr/>
+    <w:name w:val="Heading 3"/>
+    <w:link w:val="Heading3"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="Heading4">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="24"/>
+      </w:rPr>
+      <w:spacing w:before="120" w:after="80"/>
+    </w:pPr>
+    <w:name w:val="Heading 4"/>
+    <w:link w:val="Heading4Char"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="character" w:styleId="Heading4Char">
+    <w:rPr/>
+    <w:name w:val="Heading 4"/>
+    <w:link w:val="Heading4"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="Heading5">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="22"/>
+        <w:i/>
+      </w:rPr>
+      <w:spacing w:before="120" w:after="80"/>
+    </w:pPr>
+    <w:name w:val="Heading 5"/>
+    <w:link w:val="Heading5Char"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="character" w:styleId="Heading5Char">
+    <w:rPr/>
+    <w:name w:val="Heading 5"/>
+    <w:link w:val="Heading5"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="Heading6">
+    <w:pPr>
+      <w:rPr>
+        <w:sz w:val="20"/>
+        <w:i/>
+      </w:rPr>
+      <w:spacing w:before="120" w:after="80"/>
+    </w:pPr>
+    <w:name w:val="Heading 6"/>
+    <w:link w:val="Heading6Char"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:style w:type="character" w:styleId="Heading6Char">
+    <w:rPr/>
+    <w:name w:val="Heading 6"/>
+    <w:link w:val="Heading6"/>
+    <w:qFormat/>
+    <w:basedOn w:val="Normal"/>
+  </w:style>
+  <w:latentStyles/>
+</w:styles>

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -387,6 +387,48 @@ Base.show(io::IO, ::MIME"image/png", p::PNG) = write(io, p.bytes)
         reftest_docx(doc, "basic_table")
     end
 
+    @testset "Table width, layout, grid, tabs and bookmarks" begin
+        doc = W.Document(
+            W.Body([
+                W.Section([
+                    W.Table(
+                        [
+                            W.TableRow([
+                                W.TableCell(
+                                    [W.Paragraph([W.Run([W.Text("A")])])],
+                                    W.TableCellProperties(width = W.TableWidth(dxa = 3000)),
+                                ),
+                                W.TableCell([W.Paragraph([W.Run([W.Text("B")])])]),
+                            ]),
+                        ];
+                        grid = W.Twip[W.Twip(3000), W.Twip(3000)],
+                        width = W.TableWidth(pct = 100),
+                        layout = W.TableLayout.fixed,
+                    ),
+                    W.Paragraph(
+                        [W.Run([W.Text("left"), W.Tab(), W.Text("centered")])],
+                        W.ParagraphProperties(
+                            tabs = [
+                                W.TabStop(
+                                    W.Twip(4320);
+                                    alignment = W.TabAlignment.center,
+                                    leader = W.TabLeader.dot,
+                                ),
+                            ],
+                            spacing = W.Spacing(line = 360, line_rule = W.LineRule.at_least),
+                        ),
+                    ),
+                    W.Paragraph([
+                        W.BookmarkStart(1, "target"),
+                        W.Run([W.Text("bookmarked")]),
+                        W.BookmarkEnd(1),
+                    ]),
+                ]),
+            ]),
+        )
+        reftest_docx(doc, "table_width_tabs_bookmarks")
+    end
+
     @testset "Table justification" begin
         tbl(just) = W.Table([
             W.TableRow([

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -396,13 +396,13 @@ Base.show(io::IO, ::MIME"image/png", p::PNG) = write(io, p.bytes)
                             W.TableRow([
                                 W.TableCell(
                                     [W.Paragraph([W.Run([W.Text("A")])])],
-                                    W.TableCellProperties(width = W.TableWidth(dxa = 3000)),
+                                    W.TableCellProperties(width = 150W.pt),
                                 ),
                                 W.TableCell([W.Paragraph([W.Run([W.Text("B")])])]),
                             ]),
                         ];
-                        grid = W.Twip[W.Twip(3000), W.Twip(3000)],
-                        width = W.TableWidth(pct = 100),
+                        grid = [150W.pt, 150W.pt],
+                        width = 100W.percent,
                         layout = W.TableLayout.fixed,
                         justification = W.Justification.center,
                         spacing = W.Twip(50),
@@ -418,12 +418,12 @@ Base.show(io::IO, ::MIME"image/png", p::PNG) = write(io, p.bytes)
                         W.ParagraphProperties(
                             tabs = [
                                 W.TabStop(
-                                    W.Twip(4320);
+                                    216W.pt;
                                     alignment = W.TabAlignment.center,
                                     leader = W.TabLeader.dot,
                                 ),
                             ],
-                            spacing = W.Spacing(line = 360, line_rule = W.LineRule.at_least),
+                            spacing = W.Spacing(line = W.AtLeast(18W.pt)),
                         ),
                     ),
                     W.Paragraph([
@@ -1238,5 +1238,46 @@ Base.show(io::IO, ::MIME"image/png", p::PNG) = write(io, p.bytes)
         @test W.Point(6 * W.cm) / W.Inch(2 * W.cm) ≈ 3.0
         @test 2 * W.inch - 144 * W.pt == 0 * W.inch
         @test -2 * W.inch + 144 * W.pt == 0 * W.inch
+        @test 50 * W.percent == W.Percent(50)
+        @test W.percent * 50 == 50 * W.percent
+    end
+
+    @testset "Table width units" begin
+        # The unit tag and the number Word stores both follow from the type of the width given.
+        table_width(w) = string(only(W.children(W.TableProperties(width = w))))
+        cell_width(w) = string(only(W.children(W.TableCellProperties(width = w))))
+
+        @test table_width(100W.percent) == """<w:tblW w:type="pct" w:w="5000"/>"""
+        @test table_width(50W.percent) == """<w:tblW w:type="pct" w:w="2500"/>"""
+        @test table_width(2W.inch) == """<w:tblW w:type="dxa" w:w="2880"/>"""
+        @test table_width(W.Twip(3000)) == """<w:tblW w:type="dxa" w:w="3000"/>"""
+        @test table_width(W.automatic) == """<w:tblW w:type="auto" w:w="0"/>"""
+        # A width wraps its value, so the wrapper and the bare value mean the same thing.
+        @test table_width(W.TableWidth(2W.inch)) == table_width(2W.inch)
+        @test cell_width(2W.inch) == """<w:tcW w:type="dxa" w:w="2880"/>"""
+        @test cell_width(100W.percent) == """<w:tcW w:type="pct" w:w="5000"/>"""
+    end
+
+    @testset "Line spacing units" begin
+        line_attrs(line) = Dict(k => W.xmlstring(v) for (k, v) in W.attributes(W.Spacing(; line)))
+
+        @test line_attrs(100W.percent) == Dict("w:line" => "240", "w:lineRule" => "auto")
+        @test line_attrs(150W.percent) == Dict("w:line" => "360", "w:lineRule" => "auto")
+        @test line_attrs(14W.pt) == Dict("w:line" => "280", "w:lineRule" => "exact")
+        @test line_attrs(W.AtLeast(14W.pt)) == Dict("w:line" => "280", "w:lineRule" => "atLeast")
+        @test isempty(W.attributes(W.Spacing()))
+        @test Dict(k => W.xmlstring(v) for (k, v) in
+                   W.attributes(W.Spacing(before = 6W.pt, after = 6W.pt, line = 14W.pt))) == Dict(
+            "w:before" => "120",
+            "w:after" => "120",
+            "w:line" => "280",
+            "w:lineRule" => "exact",
+        )
+    end
+
+    @testset "Tab stops and grids take any length" begin
+        @test W.TabStop(3W.inch).position == W.Twip(4320)
+        @test W.Table(W.TableRow[]; grid = [1W.inch, 2W.cm]).grid ==
+              [W.Twip(1W.inch), W.Twip(2W.cm)]
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -404,6 +404,14 @@ Base.show(io::IO, ::MIME"image/png", p::PNG) = write(io, p.bytes)
                         grid = W.Twip[W.Twip(3000), W.Twip(3000)],
                         width = W.TableWidth(pct = 100),
                         layout = W.TableLayout.fixed,
+                        justification = W.Justification.center,
+                        spacing = W.Twip(50),
+                        margins = W.TableLevelCellMargins(
+                            top = 5W.pt,
+                            bottom = 5W.pt,
+                            start = 5W.pt,
+                            stop = 5W.pt,
+                        ),
                     ),
                     W.Paragraph(
                         [W.Run([W.Text("left"), W.Tab(), W.Text("centered")])],


### PR DESCRIPTION
Adds support for several Word features, following the ECMA-376 spec:

- `TableWidth` (pct/dxa) and `TableLayout`, plus a `Table` column `grid`, so a table can fill the page width or use fixed column widths.
- `Tab` and `TabStop`/`TabStops`, for tab-aligned text with leaders.
- `BookmarkStart`/`BookmarkEnd`, named anchors so hyperlinks and a table of contents can target locations in the document.
- `line`/`line_rule` on `Spacing`, for paragraph line spacing.

Each has a reference test. The additions are backwards-compatible. One existing behavior changes for spec conformance: `<w:tblCellSpacing>` now carries the required `w:type="dxa"`, and `TableProperties` children follow the `CT_TblPrBase` schema order — so the generated XML changes for tables that set cell spacing (documents render identically).

Fixes https://github.com/PumasAI/WriteDocx.jl/issues/45.