### PR TITLE
Add update_fields option to write word/settings.xml

### DIFF
--- a/src/WriteDocx.jl
+++ b/src/WriteDocx.jl
@@ -1180,14 +1180,26 @@ end
 struct Document
     body::Body
     styles::Styles
+    update_fields::Bool
 end
 
 """
-    Document(body::Body; styles::Styles = Styles([]))
+    Document(body::Body; styles::Styles = Styles([]), update_fields::Bool = false)
 
 The root object containing all other elements that make up the document.
+
+Set `update_fields = true` to have Word recompute every field (for example a hand-built
+table of contents' `PAGEREF` page numbers) the first time the document is opened, by writing
+`word/settings.xml` with `<w:updateFields w:val="true"/>`. Defaults to `false`, so existing
+callers see no change.
 """
-Document(body::Body; styles::Styles = Styles([])) = Document(body, styles)
+Document(body::Body; styles::Styles = Styles([]), update_fields::Bool = false) =
+    Document(body, styles, update_fields)
+
+# Pre-existing 2-positional-arg form (body, styles), from when Document had only those two fields —
+# kept so adding `update_fields` doesn't break a caller using this form directly instead of the
+# `styles = ...` keyword.
+Document(body::Body, styles::Styles) = Document(body, styles, false)
 
 function save(path, document::Document)
     if !endswith(path, ".docx")
@@ -1219,6 +1231,11 @@ function save(path, document::Document)
 
         f = ZipFile.addfile(zipwriter, "word/styles.xml"; method = ZipFile.Deflate)
         E.prettyprint(f, styles_xml(document.styles))
+
+        if document.update_fields
+            f = ZipFile.addfile(zipwriter, "word/settings.xml"; method = ZipFile.Deflate)
+            print(f, settings_xml())
+        end
 
         f = ZipFile.addfile(zipwriter, "word/document.xml"; method = ZipFile.Deflate)
         E.prettyprint(f, to_xml(document, rels))
@@ -1458,6 +1475,15 @@ function resolve_rel!(x::StyleRel, i, dir, prefix)
     )
 end
 
+struct SettingsRel end
+
+function resolve_rel!(x::SettingsRel, i, dir, prefix)
+    return Relationship(
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/settings",
+        prefix * "settings.xml",
+    )
+end
+
 function resolve_rel!(x::Image, i, dir, prefix)
     mktempdir() do tempdir
         imgpath = get_image_file(x, tempdir)
@@ -1491,6 +1517,7 @@ end
 function gather_rels(document::Document, zipdir)
     rels = OrderedDict{Any, Int}()
     add_rel!(rels, StyleRel())
+    document.update_fields && add_rel!(rels, SettingsRel())
     gather_rels!(rels, zipdir, document.body)
     return rels
 end
@@ -1566,6 +1593,8 @@ function content_types(rels)
             println(io, "    <Override PartName=\"/word/header$i.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml\" />")
         elseif rel isa Footer
             println(io, "    <Override PartName=\"/word/footer$i.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml\" />")
+        elseif rel isa SettingsRel
+            println(io, "    <Override PartName=\"/word/settings.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.wordprocessingml.settings+xml\" />")
         end
     end
 
@@ -1586,6 +1615,13 @@ function rels_xml(resolved_rels)
     end
 
     return doc
+end
+
+function settings_xml()
+    """
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <w:settings xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:updateFields w:val="true"/></w:settings>
+    """
 end
 
 function global_rels_xml()

--- a/src/WriteDocx.jl
+++ b/src/WriteDocx.jl
@@ -1181,6 +1181,8 @@ struct Document
     body::Body
     styles::Styles
     update_fields::Bool
+
+    Document(body::Body, styles::Styles, update_fields::Bool = false) = new(body, styles, update_fields)
 end
 
 """
@@ -1195,11 +1197,6 @@ callers see no change.
 """
 Document(body::Body; styles::Styles = Styles([]), update_fields::Bool = false) =
     Document(body, styles, update_fields)
-
-# Pre-existing 2-positional-arg form (body, styles), from when Document had only those two fields —
-# kept so adding `update_fields` doesn't break a caller using this form directly instead of the
-# `styles = ...` keyword.
-Document(body::Body, styles::Styles) = Document(body, styles, false)
 
 function save(path, document::Document)
     if !endswith(path, ".docx")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1180,6 +1180,42 @@ Base.show(io::IO, ::MIME"image/png", p::PNG) = write(io, p.bytes)
         reftest_docx(doc, "table_of_figures")
     end
 
+    @testset "update_fields (word/settings.xml)" begin
+        body = W.Body([W.Section([W.Paragraph([W.Run([W.Text("hello")])])])])
+
+        function docx_parts(doc::W.Document)
+            mktempdir() do dir
+                docxpath = joinpath(dir, "temp.docx")
+                zipdir = joinpath(dir, "unzipped")
+                W.save(docxpath, doc)
+                unzip(docxpath, zipdir)
+                parts = Dict{String,String}()
+                for (root, _, files) in walkdir(zipdir)
+                    for file in files
+                        parts[relpath(joinpath(root, file), zipdir)] = read(joinpath(root, file), String)
+                    end
+                end
+                return parts
+            end
+        end
+
+        @testset "default (update_fields = false): no settings.xml, existing callers unaffected" begin
+            parts = docx_parts(W.Document(body))
+            @test !haskey(parts, "word/settings.xml")
+            @test !occursin("settings.xml", parts["[Content_Types].xml"])
+            @test !occursin("relationships/settings", parts["word/_rels/document.xml.rels"])
+        end
+
+        @testset "update_fields = true: settings.xml written and wired into rels + content types" begin
+            parts = docx_parts(W.Document(body; update_fields = true))
+            @test haskey(parts, "word/settings.xml")
+            @test occursin("<w:updateFields w:val=\"true\"/>", parts["word/settings.xml"])
+            @test occursin("PartName=\"/word/settings.xml\"", parts["[Content_Types].xml"])
+            @test occursin("relationships/settings", parts["word/_rels/document.xml.rels"])
+            @test occursin("Target=\"settings.xml\"", parts["word/_rels/document.xml.rels"])
+        end
+    end
+
     @testset "Length calculations" begin
         @test 4 * W.cm == W.Centimeter(4)
         @test W.cm * 4 == 4 * W.cm

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1192,7 +1192,8 @@ Base.show(io::IO, ::MIME"image/png", p::PNG) = write(io, p.bytes)
                 parts = Dict{String,String}()
                 for (root, _, files) in walkdir(zipdir)
                     for file in files
-                        parts[relpath(joinpath(root, file), zipdir)] = read(joinpath(root, file), String)
+                        key = replace(relpath(joinpath(root, file), zipdir), "\\" => "/")
+                        parts[key] = read(joinpath(root, file), String)
                     end
                 end
                 return parts


### PR DESCRIPTION
Adds an `update_fields::Bool` field to `Document` (default `false`). When `true`, `save` writes `word/settings.xml` containing
`<w:updateFields w:val="true"/>`, so Word recomputes every field (e.g. a hand-built TOC's `PAGEREF` page numbers) the first time the document is opened.

Fixes #47 .

Wired the same way `styles.xml` already is: a `SettingsRel` singleton through `resolve_rel!`, added to `gather_rels` only when `update_fields` is set, plus a `content_types` override for `application/vnd.openxmlformats-officedocument.wordprocessingml.settings+xml`.

Adding the field removed `Document`'s implicit 2-arg constructor (`Document(body, styles)`), which one existing test used directly. Added that constructor back explicitly, defaulting `update_fields` to `false`.